### PR TITLE
Update config for Node 22 compatibility

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,4 +1,5 @@
-modules = ["nodejs-20", "web", "postgresql-16"]
+# Use Node.js v22 runtime
+modules = ["nodejs-22", "web", "postgresql-16"]
 run = "npm run dev"
 hidden = [".config", ".git", "generated-icon.png", "node_modules", "dist"]
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "type": "module",
   "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "cross-env NODE_ENV=development tsx watch server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -23,7 +23,10 @@ export async function setupVite(app: Express, server: Server) {
   const serverOptions = {
     middlewareMode: true,
     hmr: { server },
-    allowedHosts: true,
+    // allow serving from any host. Cast as const so TypeScript
+    // treats the value as the literal `true` instead of `boolean`
+    // which matches Vite's `ServerOptions` type
+    allowedHosts: true as const,
   };
 
   const vite = await createViteServer({


### PR DESCRIPTION
## Summary
- adjust Vite server options to satisfy TypeScript
- switch Replit runtime to Node.js 22
- declare engine requirement for Node.js 22

## Testing
- `npm run check`
- `npm run build`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68566354221483239ad473db893958c3