### PR TITLE
Add Google API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ npm install @google/genai mime
 npm install -D @types/node
 ```
 
+После обновления репозитория не забудьте заново выполнить `npm install`, чтобы
+загрузить новые зависимости, включая Google SDK.
+
 ## Режим разработки
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 ```bash
 npm install
+npm install @google/genai mime
+npm install -D @types/node
 ```
 
 ## Режим разработки

--- a/client/src/components/chat-interface.tsx
+++ b/client/src/components/chat-interface.tsx
@@ -12,9 +12,10 @@ import ReactMarkdown from "react-markdown";
 interface ChatInterfaceProps {
   activePrompt: SystemPrompt | null;
   config: ApiConfiguration | null | undefined;
+  googleMode: boolean;
 }
 
-export function ChatInterface({ activePrompt, config }: ChatInterfaceProps) {
+export function ChatInterface({ activePrompt, config, googleMode }: ChatInterfaceProps) {
   const [currentMessage, setCurrentMessage] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -58,7 +59,7 @@ export function ChatInterface({ activePrompt, config }: ChatInterfaceProps) {
 
   const chatMutation = useMutation({
     mutationFn: async (chatData: ChatRequest) => {
-      const response = await apiRequest("POST", "/api/chat", chatData);
+      const response = await apiRequest("POST", `/api/chat?google=${googleMode}`, chatData);
       
       if (!response.ok) {
         const errorData = await response.json();
@@ -173,7 +174,7 @@ export function ChatInterface({ activePrompt, config }: ChatInterfaceProps) {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, isLoading]);
 
-  const isConfigured = config?.endpoint && config?.token && config?.model;
+  const isConfigured = config?.token && config?.model && (googleMode || config?.endpoint);
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden">

--- a/client/src/components/configuration-panel.tsx
+++ b/client/src/components/configuration-panel.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { useMutation, useQueryClient, useQuery } from "@tanstack/react-query";
 import {
@@ -32,6 +33,7 @@ export function ConfigurationPanel({ expanded, onToggle, config }: Configuration
   const [endpoint, setEndpoint] = useState(config?.endpoint || "");
   const [token, setToken] = useState(config?.token || "");
   const [model, setModel] = useState(config?.model || "");
+  const [useGoogle, setUseGoogle] = useState(config?.useGoogle ?? false);
   
   const { toast } = useToast();
   const queryClient = useQueryClient();
@@ -44,12 +46,13 @@ export function ConfigurationPanel({ expanded, onToggle, config }: Configuration
       setEndpoint(config.endpoint);
       setToken(config.token);
       setModel(config.model);
+      setUseGoogle(config.useGoogle ?? false);
     }
   }, [config]);
 
   const saveConfigMutation = useMutation({
     mutationFn: async (
-      configData: { id?: number; name: string; endpoint: string; token: string; model: string },
+      configData: { id?: number; name: string; endpoint: string; token: string; model: string; useGoogle: boolean },
     ) => {
       return apiRequest("POST", "/api/config", configData);
     },
@@ -138,6 +141,7 @@ export function ConfigurationPanel({ expanded, onToggle, config }: Configuration
       endpoint: endpoint.trim(),
       token: token.trim(),
       model: model.trim(),
+      useGoogle,
     });
   };
 
@@ -174,6 +178,7 @@ export function ConfigurationPanel({ expanded, onToggle, config }: Configuration
                     setEndpoint("");
                     setToken("");
                     setModel("");
+                    setUseGoogle(false);
                   } else {
                     const id = parseInt(val);
                     setSelectedId(id);
@@ -183,6 +188,7 @@ export function ConfigurationPanel({ expanded, onToggle, config }: Configuration
                       setEndpoint(cfg.endpoint);
                       setToken(cfg.token);
                       setModel(cfg.model);
+                      setUseGoogle(cfg.useGoogle ?? false);
                       activateMutation.mutate(id);
                     }
                   }
@@ -247,6 +253,17 @@ export function ConfigurationPanel({ expanded, onToggle, config }: Configuration
                 <br />• NVIDIA: meta/llama3-70b-instruct
                 <br />• Anthropic: claude-3-sonnet-20240229
               </div>
+            </div>
+
+            <div className="flex items-center space-x-2 mt-6">
+              <Label htmlFor="useGoogle" className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                Использовать Google API
+              </Label>
+              <Switch
+                id="useGoogle"
+                checked={useGoogle}
+                onCheckedChange={(val) => setUseGoogle(val)}
+              />
             </div>
 
             <div>

--- a/client/src/components/system-prompts-sidebar.tsx
+++ b/client/src/components/system-prompts-sidebar.tsx
@@ -12,9 +12,10 @@ interface SystemPromptsSidebarProps {
   prompts: SystemPrompt[];
   activePrompt: SystemPrompt | null;
   onSelectPrompt: (prompt: SystemPrompt) => void;
+  activeModel?: string;
 }
 
-export function SystemPromptsSidebar({ prompts, activePrompt, onSelectPrompt }: SystemPromptsSidebarProps) {
+export function SystemPromptsSidebar({ prompts, activePrompt, onSelectPrompt, activeModel }: SystemPromptsSidebarProps) {
   const [newPromptName, setNewPromptName] = useState("");
   const [newPromptContent, setNewPromptContent] = useState("");
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -277,6 +278,10 @@ export function SystemPromptsSidebar({ prompts, activePrompt, onSelectPrompt }: 
         <div className="text-xs text-muted-foreground mb-1">Активный промпт:</div>
         <div className="text-sm font-medium text-foreground">
           {activePrompt ? activePrompt.name : "Не выбран"}
+        </div>
+        <div className="text-xs text-muted-foreground mb-1 mt-2">Активная модель:</div>
+        <div className="text-sm font-medium text-foreground">
+          {activeModel || "Не выбрана"}
         </div>
       </div>
     </div>

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -8,6 +8,7 @@ import type { SystemPrompt, ApiConfiguration } from "@shared/schema";
 export default function Home() {
   const [configExpanded, setConfigExpanded] = useState(true);
   const [activePrompt, setActivePrompt] = useState<SystemPrompt | null>(null);
+  const [googleMode, setGoogleMode] = useState(false);
 
   // Load prompts
   const { data: prompts = [] } = useQuery<SystemPrompt[]>({
@@ -16,7 +17,7 @@ export default function Home() {
 
   // Load configuration
   const { data: config } = useQuery<ApiConfiguration | null>({
-    queryKey: ["/api/config"],
+    queryKey: [`/api/config?google=${googleMode}`],
   });
 
   // Set first prompt as active by default
@@ -28,22 +29,26 @@ export default function Home() {
 
   return (
     <div className="h-screen flex flex-col overflow-hidden">
-      <ConfigurationPanel 
+      <ConfigurationPanel
         expanded={configExpanded}
         onToggle={() => setConfigExpanded(!configExpanded)}
         config={config}
+        googleMode={googleMode}
+        onGoogleModeChange={setGoogleMode}
       />
       
       <div className="flex flex-1 overflow-hidden">
-        <SystemPromptsSidebar 
+        <SystemPromptsSidebar
           prompts={prompts}
           activePrompt={activePrompt}
           onSelectPrompt={setActivePrompt}
+          activeModel={config?.model}
         />
         
-        <ChatInterface 
+        <ChatInterface
           activePrompt={activePrompt}
           config={config}
+          googleMode={googleMode}
         />
       </div>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@google/genai": "^1.6.0",
         "@hookform/resolvers": "^3.10.0",
         "@jridgewell/trace-mapping": "^0.3.25",
         "@neondatabase/serverless": "^0.10.4",
@@ -54,6 +55,7 @@
         "input-otp": "^1.4.2",
         "lucide-react": "^0.453.0",
         "memorystore": "^1.6.7",
+        "mime": "^3.0.0",
         "next-themes": "^0.4.6",
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
@@ -1337,6 +1339,29 @@
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
+    },
+    "node_modules/@google/genai": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.6.0.tgz",
+      "integrity": "sha512-0vn8wMGesjiEsHeFsl10T8+SFqLj7q+RSE6mml66sE+jwI7U9wW2LQ3qYtwUEaI+P8ZYeEYE5IpYmNLcRQUBPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.14.2",
+        "ws": "^8.18.0",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.22.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.11.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@hookform/resolvers": {
       "version": "3.10.0",
@@ -3774,6 +3799,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
@@ -3895,6 +3929,35 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.0.tgz",
+      "integrity": "sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3999,6 +4062,12 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -5207,6 +5276,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -5693,6 +5771,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -5785,6 +5893,32 @@
         "node": ">=4"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -5802,6 +5936,19 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
@@ -5915,6 +6062,19 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -6090,6 +6250,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -6139,6 +6311,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -6150,6 +6331,27 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/lightningcss": {
@@ -7155,15 +7357,15 @@
       }
     },
     "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -7283,6 +7485,26 @@
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-gyp-build": {
@@ -8495,6 +8717,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/send/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/serve-static": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
@@ -8913,6 +9147,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
@@ -9712,6 +9952,19 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -10281,6 +10534,22 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -10467,6 +10736,15 @@
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     },
     "node_modules/zod-validation-error": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,9 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "@google/genai": "^1.6.0",
+    "mime": "^3.0.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.7",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -155,7 +155,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       if (useGoogle) {
-        const { GoogleGenAI } = await import("@google/genai");
+        let GoogleGenAI: any;
+        try {
+          ({ GoogleGenAI } = await import("@google/genai"));
+        } catch (err) {
+          return res.status(500).json({
+            message: "Failed to load Google SDK. Ensure '@google/genai' is installed",
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
         const ai = new GoogleGenAI({ apiKey: config.token });
         const response = await ai.models.generateContent({
           model: config.model,
@@ -232,7 +240,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       // If using Google API, call via SDK
       if (useGoogle) {
-        const { GoogleGenAI } = await import("@google/genai");
+        let GoogleGenAI: any;
+        try {
+          ({ GoogleGenAI } = await import("@google/genai"));
+        } catch (err) {
+          return res.status(500).json({
+            message: "Failed to load Google SDK. Ensure '@google/genai' is installed",
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
         const ai = new GoogleGenAI({ apiKey: config.token });
         const googleMessages = apiMessages
           .filter((m) => m.role !== 'system')

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -259,10 +259,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const payload: any = {
           model: config.model,
           contents: googleMessages,
+          config: systemPrompt ? { systemInstruction: systemPrompt } : undefined,
         };
-        if (systemPrompt) {
-          payload.systemInstruction = { role: 'user', parts: [{ text: systemPrompt }] };
-        }
         const response = await ai.models.generateContent(payload);
         return res.json({
           choices: [

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -261,7 +261,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           contents: googleMessages,
         };
         if (systemPrompt) {
-          payload.config = { systemInstruction: systemPrompt };
+          payload.systemInstruction = { role: 'user', parts: [{ text: systemPrompt }] };
         }
         const response = await ai.models.generateContent(payload);
         return res.json({

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -165,16 +165,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
           });
         }
         const ai = new GoogleGenAI({ apiKey: config.token });
-        const model = ai.getGenerativeModel({ model: config.model });
-        const result = await model.generateContent({
+        const result = await ai.models.generateContent({
+          model: config.model,
           contents: [{ role: "user", parts: [{ text: "Hello" }] }],
         });
-        const response = await result.response;
-        const text = await response.text();
         return res.json({
           success: true,
           message: "API connection successful",
-          response: { text },
+          response: { text: result.text },
         });
       }
 
@@ -252,7 +250,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
           });
         }
         const ai = new GoogleGenAI({ apiKey: config.token });
-        const model = ai.getGenerativeModel({ model: config.model });
 
         const googleMessages = [
           ...(systemPrompt
@@ -264,15 +261,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
           })),
         ];
 
-        const result = await model.generateContent({ contents: googleMessages });
-        const googleResponse = await result.response;
-        const text = await googleResponse.text();
+        const result = await ai.models.generateContent({
+          model: config.model,
+          contents: googleMessages,
+        });
         return res.json({
           choices: [
             {
               message: {
                 role: "assistant",
-                content: text,
+                content: result.text,
               },
             },
           ],

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -53,7 +53,10 @@ export class MemStorage implements IStorage {
           activeId?: number;
           configs?: ApiConfiguration[];
         };
-        const configs = data.configs ?? [];
+        const configs = (data.configs ?? []).map((c) => ({
+          ...c,
+          useGoogle: c.useGoogle ?? false,
+        }));
         this.apiConfigurations = new Map(configs.map((c) => [c.id!, c]));
         const maxId = configs.reduce((m, c) => Math.max(m, c.id ?? 0), 0);
         this.currentConfigId = maxId + 1;
@@ -214,6 +217,7 @@ export class MemStorage implements IStorage {
     const config: ApiConfiguration = {
       ...insertConfig,
       id,
+      useGoogle: insertConfig.useGoogle ?? false,
     };
     this.apiConfigurations.set(id, config);
     this.activeConfigId = id;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -28,6 +28,7 @@ export const apiConfigurations = pgTable("api_configurations", {
   endpoint: text("endpoint").notNull(),
   token: text("token").notNull(),
   model: text("model").notNull(),
+  useGoogle: boolean("use_google").default(false).notNull(),
 });
 
 export const insertUserSchema = createInsertSchema(users).pick({


### PR DESCRIPTION
## Summary
- support Google Gemini API in the chat backend
- allow toggling Google API in configuration panel
- persist the new `useGoogle` flag
- document extra dependencies required for Google API

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68579f24e93083239d243dd1e6b39d8b