### PR TITLE
Add login form

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,11 +4,13 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import Home from "@/pages/home";
+import Login from "@/pages/login";
 import NotFound from "@/pages/not-found";
 
 function Router() {
   return (
     <Switch>
+      <Route path="/login" component={Login} />
       <Route path="/" component={Home} />
       <Route component={NotFound} />
     </Switch>

--- a/client/src/hooks/use-session.ts
+++ b/client/src/hooks/use-session.ts
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+import { getQueryFn } from "@/lib/queryClient";
+
+export function useSession() {
+  return useQuery<{ authenticated: boolean } | null>({
+    queryKey: ["/api/session"],
+    queryFn: getQueryFn({ on401: "returnNull" }),
+  });
+}

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,11 +1,15 @@
 import { useState, useEffect } from "react";
+import { useLocation } from "wouter";
 import { ConfigurationPanel } from "@/components/configuration-panel";
 import { SystemPromptsSidebar } from "@/components/system-prompts-sidebar";
 import { ChatInterface } from "@/components/chat-interface";
 import { useQuery } from "@tanstack/react-query";
 import type { SystemPrompt, ApiConfiguration } from "@shared/schema";
+import { useSession } from "@/hooks/use-session";
 
 export default function Home() {
+  const [, navigate] = useLocation();
+  const { data: session, isLoading: sessionLoading } = useSession();
   const [configExpanded, setConfigExpanded] = useState(true);
   const [activePrompt, setActivePrompt] = useState<SystemPrompt | null>(null);
   const [googleMode, setGoogleMode] = useState(false);
@@ -26,6 +30,14 @@ export default function Home() {
       setActivePrompt(prompts[0]);
     }
   }, [prompts, activePrompt]);
+
+  useEffect(() => {
+    if (!sessionLoading && !session) {
+      navigate("/login");
+    }
+  }, [sessionLoading, session, navigate]);
+
+  if (sessionLoading || !session) return null;
 
   return (
     <div className="h-screen flex flex-col overflow-hidden">

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -1,0 +1,58 @@
+import { useState, useEffect } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useLocation } from "wouter";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { apiRequest } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+import { useSession } from "@/hooks/use-session";
+
+export default function Login() {
+  const [, navigate] = useLocation();
+  const { data: session, isLoading } = useSession();
+  const { toast } = useToast();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+
+  useEffect(() => {
+    if (!isLoading && session) {
+      navigate("/");
+    }
+  }, [isLoading, session, navigate]);
+
+  const mutation = useMutation({
+    mutationFn: () => apiRequest("POST", "/api/login", { username, password }),
+    onSuccess: () => navigate("/"),
+    onError: () =>
+      toast({ title: "Login failed", variant: "destructive" }),
+  });
+
+  if (isLoading || session) return null;
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <Card className="w-full max-w-sm mx-4">
+        <CardHeader>
+          <CardTitle>Login</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Input
+            placeholder="Username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+          <Input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <Button className="w-full" onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+            Sign In
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,10 +1,23 @@
 import express, { type Request, Response, NextFunction } from "express";
+import session from "express-session";
+import connectMem from "memorystore";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
+
+const MemStore = connectMem(session);
+app.use(
+  session({
+    cookie: { maxAge: 86400000 },
+    store: new MemStore({ checkPeriod: 86400000 }),
+    secret: "secret",
+    resave: false,
+    saveUninitialized: false,
+  })
+);
 
 app.use((req, res, next) => {
   const start = Date.now();

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -142,6 +142,9 @@ export class MemStorage implements IStorage {
     // Load persisted API configurations for both modes
     this.loadConfigs(false);
     this.loadConfigs(true);
+
+    // Add default user
+    this.createUser({ username: "ldy", password: "123d5812dd3DDD" });
   }
 
   private initializeDefaultPrompts() {


### PR DESCRIPTION
## Summary
- add express-session setup
- create login/logout/session API routes with guard middleware
- store default user in memory
- gate home page behind login check
- add login page and route
- add useSession React hook

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6873cafc01888323a20c1cf4cf7d10bf